### PR TITLE
feature: Fix openjdk base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/openjdk:8-jdk-slim-buster
+FROM library/openjdk:8u232-jdk-slim-buster
 
 LABEL maintainer="Rodrigo Fernandes <rodrigo@codacy.com>"
 


### PR DESCRIPTION
Fixed at: 8u232-jdk-slim-buster