### PR TITLE
Update base images and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
   apt-get -y update && \
   apt-get -y install wget unzip && \
   apt-get -y install git=1:2.* && \
+  apt-get -y install make && \
   apt-get -y upgrade && \
   rm -rf "$GNUPGHOME" && \
   apt-get -y remove software-properties-common gnupg && \
@@ -53,9 +54,20 @@ RUN chmod +x /tini
 
 FROM base as withtools
 
+# Installing the latest stable apparmor version. The latest version available in Ubuntu 22 has vulnerabilities:
+# - https://scout.docker.com/vulnerabilities/id/CVE-2016-1585
+RUN \
+  APPARMOR_VERSION="3.1.6" && \
+  wget https://gitlab.com/apparmor/apparmor/-/archive/v$APPARMOR_VERSION/apparmor-v$APPARMOR_VERSION.tar && \
+  tar -xvf apparmor-v$APPARMOR_VERSION.tar && \
+  make -C apparmor-v$APPARMOR_VERSION && \
+  make -C apparmor-v$APPARMOR_VERSION install && \
+  rm -r apparmor-v$APPARMOR_VERSION/* && \
+  rm -r apparmor-v$APPARMOR_VERSION.tar
+
 RUN \
   apt-get -y update && \
-  apt-get -y install apparmor libdevmapper1.02.1 && \
+  apt-get -y install libdevmapper1.02.1 && \
   apt-get -y install libltdl-dev && \
   ln -s /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && \
   apt-get purge -y $(apt-cache search '~c' | awk '{ print $2 }') && \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ WITHTOOLS_IMAGE_NAME=codacy/withtools
 VERSION?=$(shell cat .version || echo dev)
 OPENJ9_VERSION?=openj9-$(VERSION)
 OPENJDK17_VERSION?=jre17-$(VERSION)
-BASE_IMAGE_OPENJDK=adoptopenjdk/openjdk8:jre8u372-b07-ubuntu
-BASE_IMAGE_OPENJDK17=eclipse-temurin:17.0.7_7-jdk-focal
-BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:jre8u372-b07_openj9-0.38.0-ubuntu
+BASE_IMAGE_OPENJDK=adoptopenjdk/openjdk8:x86_64-ubuntu-jre8u382-b05
+BASE_IMAGE_OPENJDK17=eclipse-temurin:17.0.8_7-jdk-focal
+BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u382-b05_openj9-0.40.0
 
 all: docker_build ## produce the docker image
 


### PR DESCRIPTION
Trying to update the base images to more recent versions.

Also trying to update `apparmor` to a more recent version as an attempt to fix [CVE-2016-1585](https://scout.docker.com/vulnerabilities/id/CVE-2016-1585). Ubuntu version 22 has no updates for this yet, but there is an [available fix](https://gitlab.com/apparmor/apparmor/-/merge_requests/1054) in the official repository.

For more info on the Ubuntu fix, check [this link](https://bugs.launchpad.net/apparmor/+bug/1597017).