### PR TITLE
bump: openj9 to fix CVE-2024-50264

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OPENJ9_VERSION?=openj9-$(VERSION)
 OPENJDK17_VERSION?=jre17-$(VERSION)
 BASE_IMAGE_OPENJDK=adoptopenjdk/openjdk8:x86_64-ubuntu-jre8u432-b06
 BASE_IMAGE_OPENJDK17=eclipse-temurin:17.0.12_7-jdk-focal
-BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u422-b05_openj9-0.46.1
+BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u432-b06_openj9-0.48.0
 
 all: docker_build ## produce the docker image
 


### PR DESCRIPTION
https://scout.docker.com/vulnerabilities/id/CVE-2024-50264?s=ubuntu&n=linux&ns=ubuntu&t=deb&osn=ubuntu&osv=20.04&vr=%3C5.4.0-204.224

<img width="933" alt="Screenshot 2024-12-18 at 11 33 36" src="https://github.com/user-attachments/assets/38fe9b20-7618-4751-a86a-39d52bdcbd6b" />
