### PR TITLE
Update base images to latest patch versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ VERSION?=$(shell cat .version || echo dev)
 OPENJ9_VERSION?=openj9-$(VERSION)
 OPENJDK11_VERSION?=jre11-$(VERSION)
 OPENJDK17_VERSION?=jre17-$(VERSION)
-BASE_IMAGE_OPENJDK=adoptopenjdk/openjdk8:x86_64-ubuntu-jre8u462-b08
+BASE_IMAGE_OPENJDK=adoptopenjdk/openjdk8:x86_64-ubuntu-jre8u502-b07
 BASE_IMAGE_OPENJDK11=eclipse-temurin:11-jre-focal
 BASE_IMAGE_OPENJDK17=eclipse-temurin:17.0.19_10-jre-jammy
-BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u462-b08_openj9-0.53.0
+BASE_IMAGE_OPENJ9=adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u482-b08.1_openj9-0.57.0
 
 all: docker_build ## produce the docker image
 


### PR DESCRIPTION
## Summary
- Bump `adoptopenjdk/openjdk8`: `jre8u462-b08` -> `jre8u502-b07`
- Bump JDK17 (`eclipse-temurin`): `17.0.18_8-jre-jammy` -> `17.0.19_10-jre-jammy`
- Bump `adoptopenjdk/openjdk8-openj9`: `jre8u462-b08_openj9-0.53.0` -> `jre8u482-b08.1_openj9-0.57.0`
- JDK11 (`eclipse-temurin:11-jre-focal`) left unpinned/unchanged, floating tag already latest

All new tags verified pullable against Docker Hub registry manifest API.

## Test plan
- [ ] CI docker build passes for all 4 targets